### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python black_jack.py"

--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ Here are the features:
 - The player can stand or hit.
 - The player can pick their betting amount.
 - Player can win, loose, or bust, etc...
+
+[![Run on Repl.it](https://repl.it/badge/github/MaverickApekshit/black_jack)](https://repl.it/github/MaverickApekshit/black_jack)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@MaverickApe/blackjack).